### PR TITLE
bump upstream to restore missing wp script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 DOCKER_REPO ?= drud/nginx-php-fpm7-local
 
 # Upstream repo used in the Dockerfile
-NGINX_LOCAL_UPSTREAM_FPM7_REPO_TAG ?= v0.3.3
+NGINX_LOCAL_UPSTREAM_FPM7_REPO_TAG ?= v0.3.4
 UPSTREAM_REPO ?= drud/nginx-php-fpm7:$(NGINX_LOCAL_UPSTREAM_FPM7_REPO_TAG)
 
 # Top-level directories to build


### PR DESCRIPTION
## The Problem:
wp wrapper script was inadvertently removed in upstream
## The Fix:
Update to new upstream release to restore the missing script.
## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

