### PR TITLE
updates upstream for separated error/access logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 DOCKER_REPO ?= drud/nginx-php-fpm7-local
 
 # Upstream repo used in the Dockerfile
-NGINX_LOCAL_UPSTREAM_FPM7_REPO_TAG ?= v0.3.4
+NGINX_LOCAL_UPSTREAM_FPM7_REPO_TAG ?= v0.4.0
 UPSTREAM_REPO ?= drud/nginx-php-fpm7:$(NGINX_LOCAL_UPSTREAM_FPM7_REPO_TAG)
 
 # Top-level directories to build


### PR DESCRIPTION
## The Problem:
We want separated error and access logs per drud/ddev#87
## The Fix:
This updates upstream container, which provides the desired change.
## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):
drud/ddev#87
## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

