### PR TITLE
adds .my.cnf for easier mysql usage

### DIFF
--- a/files/root/.my.cnf
+++ b/files/root/.my.cnf
@@ -1,0 +1,5 @@
+[client]
+user=db
+password=db
+database=db
+host=db


### PR DESCRIPTION
## The Problem:
Currently, a user wanting to use the mysql client from the web container would need to specify all connection credentials manually, determining the connection details using ddev describe. We can easily make this not a thing by providing a my.cnf with the necessary credentials.
## The Fix:
This adds a my.cnf to the web container pre-configured with credentials.

## The Test:
Build this container locally with `make VERSION=my-creds`
Update the config.yaml of a ddev site to use the my-creds image tag for web *and* db images.
Start a ddev site
Run "ddev ssh"
Run "mysql" in the ssh session. This should automatically connect using the "db" user, and be connected to the "db" database already. If you perform a site installation, you can verify this by running SHOW TABLES and seeing the usual tables for the CMS you installed.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):
drud/ddev#285
## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

