### PR TITLE
Add error pages to nginx configuration

### DIFF
--- a/files/etc/nginx/nginx.conf
+++ b/files/etc/nginx/nginx.conf
@@ -1,0 +1,127 @@
+# Configuration File - Nginx Server Configs
+# http://nginx.org/en/docs/dirindex.html
+
+# Run as a unique, less privileged user for security reasons.
+user nginx nginx;
+
+# Sets the worker threads to the number of CPU cores available in the system for best performance.
+# Should be > the number of CPU cores.
+# Maximum number of connections = worker_processes * worker_connections
+worker_processes auto;
+
+# Maximum number of open files per worker process.
+# Should be > worker_connections.
+# worker_rlimit_nofile 8192;
+
+events {
+  # If you need more connections than this, you start optimizing your OS.
+  # That's probably the point at which you hire people who are smarter than you as this is *a lot* of requests.
+  # Should be < worker_rlimit_nofile.
+  worker_connections 1024;
+}
+
+# Log errors and warnings to this file
+# This is only used when you don't override it on a server{} level
+# error_log  logs/error.log warn;
+
+# The file storing the process ID of the main process
+# pid        /var/run/nginx.pid;
+
+http {
+
+  # Hide nginx version information.
+  server_tokens off;
+
+  # Specify MIME types for files.
+  include       mime.types;
+  default_type  application/octet-stream;
+
+  # Update charset_types to match updated mime.types.
+  # text/html is always included by charset module.
+  charset_types text/css text/plain text/vnd.wap.wml application/javascript application/json application/rss+xml application/xml;
+
+  # Include $http_x_forwarded_for within default format used in log files
+  # log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+  #                   '$status $body_bytes_sent "$http_referer" '
+  #                   '"$http_user_agent" "$http_x_forwarded_for"';
+
+  # Log access to this file
+  # This is only used when you don't override it on a server{} level
+  # access_log logs/access.log main;
+
+  # How long to allow each connection to stay idle.
+  # Longer values are better for each individual client, particularly for SSL,
+  # but means that worker connections are tied up longer.
+  keepalive_timeout 2;
+
+  # Speed up file transfers by using sendfile() to copy directly
+  # between descriptors rather than using read()/write().
+  # For performance reasons, on FreeBSD systems w/ ZFS
+  # this option should be disabled as ZFS's ARC caches
+  # frequently used files in RAM by default.
+  sendfile        on;
+
+  # Don't send out partial frames; this increases throughput
+  # since TCP frames are filled up before being sent out.
+  # tcp_nopush      on;
+
+  # Sets the maximum allowed size of the client request body, specified in the
+  # "Content-Length" request header field. If the size in a request exceeds the
+  # configured value, the 413 error is returned to the client.
+  client_max_body_size 100m;
+
+  # Enable gzip compression.
+  gzip on;
+
+  # Compression level (1-9).
+  # 5 is a perfect compromise between size and CPU usage, offering about
+  # 75% reduction for most ASCII files (almost identical to level 9).
+  gzip_comp_level    5;
+
+  # Don't compress anything that's already small and unlikely to shrink much
+  # if at all (the default is 20 bytes, which is bad as that usually leads to
+  # larger files after gzipping).
+  gzip_min_length    256;
+
+  # Compress data even for clients that are connecting to us via proxies,
+  # identified by the "Via" header (required for CloudFront).
+  gzip_proxied       any;
+
+  # Tell proxies to cache both the gzipped and regular version of a resource
+  # whenever the client's Accept-Encoding capabilities header varies;
+  # Avoids the issue where a non-gzip capable client (which is extremely rare
+  # today) would display gibberish if their proxy gave them the gzipped version.
+  gzip_vary          on;
+
+  # Compress all output labeled with one of the following MIME-types.
+  gzip_types
+    application/atom+xml
+    application/javascript
+    application/json
+    application/ld+json
+    application/manifest+json
+    application/rss+xml
+    application/vnd.geo+json
+    application/vnd.ms-fontobject
+    application/x-font-ttf
+    application/x-web-app-manifest+json
+    application/xhtml+xml
+    application/xml
+    font/opentype
+    image/bmp
+    image/svg+xml
+    image/x-icon
+    text/cache-manifest
+    text/css
+    text/plain
+    text/vcard
+    text/vnd.rim.location.xloc
+    text/vtt
+    text/x-component
+    text/x-cross-domain-policy;
+
+  # Include files in the sites-enabled folder.
+  include /etc/nginx/sites-enabled/*;
+}
+
+daemon off;

--- a/files/etc/nginx/sites-available/default.conf
+++ b/files/etc/nginx/sites-available/default.conf
@@ -1,0 +1,107 @@
+server {
+    listen 80; ## listen for ipv4; this line is default and implied
+    listen [::]:80 default ipv6only=on; ## listen for ipv6
+    root /var/www/html/docroot;
+    index index.php index.htm index.html;
+    # Make site accessible from http://localhost/
+
+    server_name _;
+
+    # Disable sendfile as per https://docs.vagrantup.com/v2/synced-folders/virtualbox.html
+    sendfile off;
+    error_log /var/log/nginx/error.log info;
+    access_log /var/log/nginx/error.log;
+
+    location / {
+        # First attempt to serve request as file, then
+        # as directory, then fall back to index.html
+        try_files $uri $uri/ /index.php?q=$uri&$args;
+    }
+
+    location @rewrite {
+        # For D7 and above:
+        # Clean URLs are handled in drupal_environment_initialize().
+        rewrite ^ /index.php;
+    }
+
+    # Fighting with Styles? This little gem is amazing.
+    # This is for D7 and D8
+    location ~ ^/sites/.*/files/styles/ {
+        try_files $uri @rewrite;
+    }
+
+    # pass the PHP scripts to FastCGI server listening on socket
+    location ~ \.php$ {
+        try_files $uri =404;
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass unix:/run/php/php7.0-fpm.sock;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param SCRIPT_NAME $fastcgi_script_name;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_intercept_errors on;
+        fastcgi_param SERVER_NAME $host;
+    }
+
+    # Expire rules for static content
+    # Feed
+    location ~* \.(?:rss|atom)$ {
+        expires 1h;
+    }
+
+    # Media: images, icons, video, audio, HTC
+    location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc)$ {
+        expires 1M;
+        access_log off;
+        add_header Cache-Control "public";
+    }
+
+    # Prevent clients from accessing hidden files (starting with a dot)
+    # This is particularly important if you store .htpasswd files in the site hierarchy
+    # Access to `/.well-known/` is allowed.
+    # https://www.mnot.net/blog/2010/04/07/well-known
+    # https://tools.ietf.org/html/rfc5785
+    location ~* /\.(?!well-known\/) {
+        deny all;
+    }
+
+    # Prevent clients from accessing to backup/config/source files
+    location ~* (?:\.(?:bak|conf|dist|fla|in[ci]|log|psd|sh|sql|sw[op])|~)$ {
+        deny all;
+    }
+
+    ## Regular private file serving (i.e. handled by Drupal).
+    location ^~ /system/files/ {
+        ## For not signaling a 404 in the error log whenever the
+        ## system/files directory is accessed add the line below.
+        ## Note that the 404 is the intended behavior.
+        log_not_found off;
+        access_log off;
+        expires 30d;
+        try_files $uri @rewrite;
+    }
+
+    ## provide a health check endpoint
+    location /healthcheck {
+        access_log off;
+        return 200;
+    }
+
+    error_page 500 501 502 503 /50x.html;
+    location = /50x.html {
+            root   /usr/share/nginx/html;
+    }
+	error_page 403 /403.html;
+	location = /403.html {
+			root   /usr/share/nginx/html;
+	}
+	error_page 404 /404.html;
+	location = /404.html {
+			root   /usr/share/nginx/html;
+	}
+	error_page 400 401 /40x.html;
+	location = /40x.html {
+			root   /usr/share/nginx/html;
+	}
+
+}

--- a/files/etc/nginx/sites-available/default.conf
+++ b/files/etc/nginx/sites-available/default.conf
@@ -91,14 +91,6 @@ server {
     location = /50x.html {
             root   /usr/share/nginx/html;
     }
-	error_page 403 /403.html;
-	location = /403.html {
-			root   /usr/share/nginx/html;
-	}
-	error_page 404 /404.html;
-	location = /404.html {
-			root   /usr/share/nginx/html;
-	}
 	error_page 400 401 /40x.html;
 	location = /40x.html {
 			root   /usr/share/nginx/html;

--- a/files/usr/share/nginx/html/403.html
+++ b/files/usr/share/nginx/html/403.html
@@ -1,0 +1,2 @@
+<h1 style='color:red'>Error 403: Access Denied</h1>
+<p>Web container: Access denied to this page.</p>

--- a/files/usr/share/nginx/html/404.html
+++ b/files/usr/share/nginx/html/404.html
@@ -1,0 +1,2 @@
+<h1 style='color:red'>Error 404: Not found</h1>
+<p>Web container: Page was not found</p>

--- a/files/usr/share/nginx/html/40x.html
+++ b/files/usr/share/nginx/html/40x.html
@@ -1,2 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>ddev web container: 40x (400 or 401): Bad request or unauthorized</title>
+    <style>
+        body {
+            width: 35em;
+            margin: 0 auto;
+            font-family: Tahoma, Verdana, Arial, sans-serif;
+        }
+    </style>
+</head>
+<body>
 <h1 style='color:red'>Error 40x: (400 or 401)</h1>
-<p>Web container: 400 (Bad Request) or 401 (Unauthorized) errors.</p>
+<p>ddev web container: 400 (Bad Request) or 401 (Unauthorized) errors.</p>
+</body>
+</html>

--- a/files/usr/share/nginx/html/40x.html
+++ b/files/usr/share/nginx/html/40x.html
@@ -1,0 +1,2 @@
+<h1 style='color:red'>Error 40x: (400 or 401)</h1>
+<p>Web container: 400 (Bad Request) or 401 (Unauthorized) errors.</p>

--- a/files/usr/share/nginx/html/50x.html
+++ b/files/usr/share/nginx/html/50x.html
@@ -1,2 +1,18 @@
-<h1>Oops! Something went wrong.. (500/50x error).</h1>
-<p>The web container's webserver had a 50x error.</p>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>ddev web container: 500 or 501: Internal Server Error or Unimplemented</title>
+    <style>
+        body {
+            width: 35em;
+            margin: 0 auto;
+            font-family: Tahoma, Verdana, Arial, sans-serif;
+        }
+    </style>
+</head>
+<body>
+
+<h1 style='color:red'>ddev web container: 500 or 501: Internal Server Error or Unimplemented</h1>
+<p>The ddev web container's webserver had a 500 or 501 error, usually something wrong with PHP code or configuration.</p>
+</body>
+</html>

--- a/files/usr/share/nginx/html/50x.html
+++ b/files/usr/share/nginx/html/50x.html
@@ -1,0 +1,2 @@
+<h1>Oops! Something went wrong.. (500/50x error).</h1>
+<p>The web container's webserver had a 50x error.</p>


### PR DESCRIPTION
## The Problem:

It's hard for users to figure out which nginx instance is throwing an error. This adds error pages that specifically identify the error as coming from the web container. 

## The Fix:

## The Test:

Mostly it will be best to test this in the master issue, https://github.com/drud/ddev/issues/262

Deploy a site as described in https://github.com/drud/ddev/issues/262, then break the site with various techniques:
* Change the site's .ddev/config.yml to point to drud/nginx-php-fpm7-local:v0.6.1-provisional
* Introduce a PHP error into Drupal's index.php to get a 500 error

In each case, the error page should identify the error and the container which is the source of the error.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

OP/Master ticket: https://github.com/drud/ddev/issues/262

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

****After approval, a version bump to v0.6.1 is required.
