### PR TITLE
Use envsubst to set nginx docroot

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -7,7 +7,7 @@ ENV MH_SMTP_BIND_ADDR 127.0.0.1:1025
 
 ENV PHP_INI /etc/php/7.0/fpm/php.ini
 
-ENV NGINX_SITE_TEMPLATE /etc/nginx/nginx-site.env.conf
+ENV NGINX_SITE_TEMPLATE /etc/nginx/nginx-site.conf
 ENV NGINX_DOCROOT /var/www/html
 # Defines vars in colon-separated notation to be subsituted with values for NGINX_SITE_TEMPLATE on start
 ENV NGINX_SITE_VARS '$NGINX_DOCROOT'
@@ -20,7 +20,10 @@ RUN apt-get update && \
 	rm -rf /var/lib/apt/lists/*
 
 ADD https://github.com/mailhog/MailHog/releases/download/v${MAILHOG_VERSION}/MailHog_linux_amd64 /usr/bin/mailhog
-RUN chmod ugo+x /usr/bin/mailhog
+
+RUN chmod ugo+x /usr/bin/mailhog && \
+    rm /etc/nginx/sites-enabled/default.conf && \
+    ln -s /etc/nginx/sites-available/nginx-site.conf /etc/nginx/sites-enabled/nginx-site.conf
 
 ADD files /
 

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -22,7 +22,7 @@ RUN apt-get update && \
 ADD https://github.com/mailhog/MailHog/releases/download/v${MAILHOG_VERSION}/MailHog_linux_amd64 /usr/bin/mailhog
 
 RUN chmod ugo+x /usr/bin/mailhog && \
-    rm /etc/nginx/sites-enabled/default.conf && \
+    rm /etc/nginx/sites-enabled/default.conf /etc/nginx/sites-available/default.conf && \
     ln -s /etc/nginx/sites-available/nginx-site.conf /etc/nginx/sites-enabled/nginx-site.conf
 
 ADD files /

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -7,9 +7,12 @@ ENV MH_SMTP_BIND_ADDR 127.0.0.1:1025
 
 ENV PHP_INI /etc/php/7.0/fpm/php.ini
 
+ENV NGINX_SITE_TEMPLATE /etc/nginx/nginx-site.env.conf
+ENV NGINX_DOCROOT /var/www/html
+
 RUN apt-get update && \
     apt-get install --no-install-recommends --no-install-suggests -y \
-        iputils-ping telnet netcat6 iproute2 vim nano php7.0-xdebug  && \
+        iputils-ping telnet netcat6 iproute2 vim nano php7.0-xdebug gettext && \
     apt-get autoremove -y && \
     apt-get clean -y && \
 	rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -9,6 +9,8 @@ ENV PHP_INI /etc/php/7.0/fpm/php.ini
 
 ENV NGINX_SITE_TEMPLATE /etc/nginx/nginx-site.env.conf
 ENV NGINX_DOCROOT /var/www/html
+# Defines vars in colon-separated notation to be subsituted with values for NGINX_SITE_TEMPLATE on start
+ENV NGINX_SITE_VARS '$NGINX_DOCROOT'
 
 RUN apt-get update && \
     apt-get install --no-install-recommends --no-install-suggests -y \

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,6 @@ test: container
 	docker exec -it web-local-test php --version | grep "PHP 7"
 	curl -s localhost:1081/test/test-email.php | grep "Test email sent"
 	@docker stop web-local-test && docker rm web-local-test
-	docker run -p 1081:80 -e "DOCROOT=potato" -e "NGINX_SITE_TEMPLATE=/test-custom.conf" -v `pwd`/test/test-custom.conf:/test-custom.conf -d --name web-local-test -d `awk '{print $$1}' .docker_image`
+	docker run -p 1081:80 -e "DOCROOT=potato" -v `pwd`/test/test-custom.conf:/var/www/html/.ddev/nginx-site.conf -d --name web-local-test -d `awk '{print $$1}' .docker_image`
 	docker exec -it web-local-test cat /etc/nginx/sites-available/default.conf | grep "docroot is /var/www/html/potato in custom conf"
 	@docker stop web-local-test && docker rm web-local-test

--- a/Makefile
+++ b/Makefile
@@ -50,5 +50,5 @@ test: container
 	curl -s localhost:1081/test/test-email.php | grep "Test email sent"
 	@docker stop web-local-test && docker rm web-local-test
 	docker run -p 1081:80 -e "DOCROOT=potato" -v `pwd`/test/test-custom.conf:/var/www/html/.ddev/nginx-site.conf -d --name web-local-test -d `awk '{print $$1}' .docker_image`
-	docker exec -it web-local-test cat /etc/nginx/sites-available/default.conf | grep "docroot is /var/www/html/potato in custom conf"
+	docker exec -it web-local-test cat /etc/nginx/sites-available/nginx-site.conf | grep "docroot is /var/www/html/potato in custom conf"
 	@docker stop web-local-test && docker rm web-local-test

--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,11 @@ include build-tools/makefile_components/base_push.mak
 test: container
 	@docker stop web-local-test || true
 	@docker rm web-local-test || true
-	docker run -p 1081:80 -d --name web-local-test -d `awk '{print $$1}' .docker_image`
+	docker run -p 1081:80 -e "DOCROOT=docroot" -d --name web-local-test -d `awk '{print $$1}' .docker_image`
 	CONTAINER_NAME=web-local-test test/containercheck.sh
 	docker exec -it web-local-test php --version | grep "PHP 7"
 	curl -s localhost:1081/test/test-email.php | grep "Test email sent"
+	@docker stop web-local-test && docker rm web-local-test
+	docker run -p 1081:80 -e "DOCROOT=potato" -e "NGINX_SITE_TEMPLATE=/test-custom.conf" -v `pwd`/test/test-custom.conf:/test-custom.conf -d --name web-local-test -d `awk '{print $$1}' .docker_image`
+	docker exec -it web-local-test cat /etc/nginx/sites-available/default.conf | grep "docroot is /var/www/html/potato in custom conf"
 	@docker stop web-local-test && docker rm web-local-test

--- a/files/etc/nginx/nginx-site.conf
+++ b/files/etc/nginx/nginx-site.conf
@@ -1,6 +1,8 @@
 server {
     listen 80; ## listen for ipv4; this line is default and implied
     listen [::]:80 default ipv6only=on; ## listen for ipv6
+    # The $NGINX_DOCROOT variable is substituted with
+    # its value when the container is started.
     root $NGINX_DOCROOT;
     index index.php index.htm index.html;
     # Make site accessible from http://localhost/

--- a/files/etc/nginx/nginx-site.conf
+++ b/files/etc/nginx/nginx-site.conf
@@ -1,12 +1,12 @@
 server {
     listen 80; ## listen for ipv4; this line is default and implied
     listen [::]:80 default ipv6only=on; ## listen for ipv6
-    # The $NGINX_DOCROOT variable is substituted with
+    # The NGINX_DOCROOT variable is substituted with
     # its value when the container is started.
     root $NGINX_DOCROOT;
     index index.php index.htm index.html;
-    # Make site accessible from http://localhost/
 
+    # Make site accessible from http://localhost/
     server_name _;
 
     # Disable sendfile as per https://docs.vagrantup.com/v2/synced-folders/virtualbox.html
@@ -26,8 +26,7 @@ server {
         rewrite ^ /index.php;
     }
 
-    # Fighting with Styles? This little gem is amazing.
-    # This is for D7 and D8
+    # Handle image styles for Drupal 7+
     location ~ ^/sites/.*/files/styles/ {
         try_files $uri @rewrite;
     }
@@ -93,9 +92,9 @@ server {
     location = /50x.html {
             root   /usr/share/nginx/html;
     }
-	error_page 400 401 /40x.html;
-	location = /40x.html {
-			root   /usr/share/nginx/html;
-	}
+    error_page 400 401 /40x.html;
+    location = /40x.html {
+            root   /usr/share/nginx/html;
+    }
 
 }

--- a/files/etc/nginx/nginx-site.env.conf
+++ b/files/etc/nginx/nginx-site.env.conf
@@ -1,7 +1,7 @@
 server {
     listen 80; ## listen for ipv4; this line is default and implied
     listen [::]:80 default ipv6only=on; ## listen for ipv6
-    root /var/www/html/docroot;
+    root $NGINX_DOCROOT;
     index index.php index.htm index.html;
     # Make site accessible from http://localhost/
 

--- a/files/start.sh
+++ b/files/start.sh
@@ -5,6 +5,10 @@ if [ -n "$DOCROOT" ] ; then
     export NGINX_DOCROOT=/var/www/html/"$DOCROOT"
 fi
 
+if [ -f /var/www/html/.ddev/nginx-site.conf ] ; then
+    export NGINX_SITE_TEMPLATE=/var/www/html/.ddev/nginx-site.conf
+fi
+
 # Substitute values of environment variables in nginx configuration
 envsubst "$NGINX_SITE_VARS" < "$NGINX_SITE_TEMPLATE" > /etc/nginx/sites-available/default.conf
 

--- a/files/start.sh
+++ b/files/start.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# Update full path NGINX_DOCROOT if DOCROOT env is provided
+if [ -n "$DOCROOT" ] ; then
+    NGINX_DOCROOT=/var/www/html/"$DOCROOT"
+fi
+
+# Substitute values of environment variables in nginx configuration
+envsubst < "$NGINX_SITE_TEMPLATE" > /etc/nginx/sites-available/default.conf
+
 # Change nginx to UID/GID of the docker user
 if [ -n "$DDEV_UID" ] ; then
     usermod -u $DDEV_UID nginx

--- a/files/start.sh
+++ b/files/start.sh
@@ -2,7 +2,7 @@
 
 # Update full path NGINX_DOCROOT if DOCROOT env is provided
 if [ -n "$DOCROOT" ] ; then
-    NGINX_DOCROOT=/var/www/html/"$DOCROOT"
+    export NGINX_DOCROOT=/var/www/html/"$DOCROOT"
 fi
 
 # Substitute values of environment variables in nginx configuration

--- a/files/start.sh
+++ b/files/start.sh
@@ -2,7 +2,7 @@
 
 # Update full path NGINX_DOCROOT if DOCROOT env is provided
 if [ -n "$DOCROOT" ] ; then
-    export NGINX_DOCROOT=/var/www/html/"$DOCROOT"
+    export NGINX_DOCROOT="/var/www/html/$DOCROOT"
 fi
 
 if [ -f /var/www/html/.ddev/nginx-site.conf ] ; then
@@ -10,7 +10,7 @@ if [ -f /var/www/html/.ddev/nginx-site.conf ] ; then
 fi
 
 # Substitute values of environment variables in nginx configuration
-envsubst "$NGINX_SITE_VARS" < "$NGINX_SITE_TEMPLATE" > /etc/nginx/sites-available/default.conf
+envsubst "$NGINX_SITE_VARS" < "$NGINX_SITE_TEMPLATE" > /etc/nginx/sites-available/nginx-site.conf
 
 # Change nginx to UID/GID of the docker user
 if [ -n "$DDEV_UID" ] ; then

--- a/files/start.sh
+++ b/files/start.sh
@@ -6,7 +6,7 @@ if [ -n "$DOCROOT" ] ; then
 fi
 
 # Substitute values of environment variables in nginx configuration
-envsubst < "$NGINX_SITE_TEMPLATE" > /etc/nginx/sites-available/default.conf
+envsubst "$NGINX_SITE_VARS" < "$NGINX_SITE_TEMPLATE" > /etc/nginx/sites-available/default.conf
 
 # Change nginx to UID/GID of the docker user
 if [ -n "$DDEV_UID" ] ; then

--- a/test/test-custom.conf
+++ b/test/test-custom.conf
@@ -1,0 +1,1 @@
+docroot is $NGINX_DOCROOT in custom conf


### PR DESCRIPTION
## The Problem:
drud/ddev#189 OP. We previously adapted the container mount to reflect the docroot for a site. This is problematic if the site depends on assets above the docroot. 

## The Fix:
This PR replaces the docroot path in the nginx config with a variable, and uses envsubst to substitute the value of the environment variable. 

## The Test:
This should be tested as part of drud/ddev#314. Testing instructions are provided there.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->
I'll be looking to add tests for setting the docroot, and potentially for replacing the nginx configuration with an alternative version.

## Related Issue Link(s):
drud/ddev#189
drud/ddev#314

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->
A new tag will need to be pushed after merge.
