### PR TITLE
Upgrade upstream container to pick up drush and wp-cli

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -12,11 +12,11 @@ ENV NGINX_DOCROOT /var/www/html
 # Defines vars in colon-separated notation to be subsituted with values for NGINX_SITE_TEMPLATE on start
 ENV NGINX_SITE_VARS '$NGINX_DOCROOT'
 
-RUN apt-get update && \
-    apt-get install --no-install-recommends --no-install-suggests -y \
+RUN apt-get -qq update && \
+    apt-get -qq install --no-install-recommends --no-install-suggests -y \
         iputils-ping telnet netcat6 iproute2 vim nano php7.0-xdebug gettext && \
-    apt-get autoremove -y && \
-    apt-get clean -y && \
+    apt-get -qq autoremove -y && \
+    apt-get -qq clean -y && \
 	rm -rf /var/lib/apt/lists/*
 
 ADD https://github.com/mailhog/MailHog/releases/download/v${MAILHOG_VERSION}/MailHog_linux_amd64 /usr/bin/mailhog

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 DOCKER_REPO ?= drud/nginx-php-fpm7-local
 
 # Upstream repo used in the Dockerfile
-NGINX_LOCAL_UPSTREAM_FPM7_REPO_TAG ?= v0.4.0
+NGINX_LOCAL_UPSTREAM_FPM7_REPO_TAG ?= v0.4.1
 UPSTREAM_REPO ?= drud/nginx-php-fpm7:$(NGINX_LOCAL_UPSTREAM_FPM7_REPO_TAG)
 
 # Top-level directories to build


### PR DESCRIPTION
## The Problem:

We need an upgraded drush for https://github.com/drud/ddev/issues/331, it comes from the upstream container. Bump the version of the upstream container.

## The Fix:

## The Test:

This can be tested as part of resolving https://github.com/drud/ddev/issues/331

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

