### PR TITLE
adds ncurses-bin to get tput

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -14,7 +14,7 @@ ENV NGINX_SITE_VARS '$NGINX_DOCROOT'
 
 RUN apt-get -qq update && \
     apt-get -qq install --no-install-recommends --no-install-suggests -y \
-        iputils-ping telnet netcat6 iproute2 vim nano php7.0-xdebug gettext && \
+        iputils-ping telnet netcat6 iproute2 vim nano php7.0-xdebug gettext ncurses-bin && \
     apt-get -qq autoremove -y && \
     apt-get -qq clean -y && \
 	rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## The Problem:
Some wp-cli commands complain if "tput" is not available on the system. We also don't get nicely colored outputs from wp-cli or drush without it.

## The Fix:
This adds the ncurses-bin package, which contains tput. This puts wp-cli at ease, and gives us nice colored output from drush and wp-cli commands.

## The Test:
Running "wp" commands should not complain about tput ("wp config get" is a command I saw the error on). If you run a drush command that generates an error ("drush pml" on a wordpress site gets you an error), you should see the [error] text on the right of the screen in red.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

