### PR TITLE
Add drushrc to skip prompts and add URI

### DIFF
--- a/files/etc/drush/drushrc.php
+++ b/files/etc/drush/drushrc.php
@@ -1,0 +1,6 @@
+<?php
+if (!empty($_ENV['DDEV_URL'])) {
+    $options['uri'] = $_ENV['DDEV_URL'];
+}
+# Skip confirmations since `ddev exec` cannot support interactive prompts
+$options['yes'] = 1;


### PR DESCRIPTION
## The Problem:
D8 doesn't respect the $base_url set in settings.php, which results in things like `drush uli` using 'default' as the URL for the login links it generates.

Additionally, we can't support interactive prompts through ddev exec, so running anything which results in a prompt causes ddev exec to hang indefinitely. What is happening is not very apparent to the user.

## The Fix:
This PR adds a drushrc.php which automatically skips confirmation prompts. It also sets the default URI for all commands.

## The Test:
I've pushed a provisional "drushrc" tag for this repo. Simply spin up a site using that, and give commands which use prompts and/or output URLs a try. 