### PR TITLE
Add root gitconfig with autocrlf

### DIFF
--- a/files/root/.gitconfig
+++ b/files/root/.gitconfig
@@ -1,0 +1,2 @@
+[core]
+	autocrlf = input


### PR DESCRIPTION
## The Problem:

Our users will use git from within the container, but there is no gitconfig, and as a result things like `git status` show problematic results wrt linefeeds.

This adds a gitconfig with  the very standard (for linux/mac autocrlf=input) (see https://help.github.com/articles/dealing-with-line-endings/#platform-linux)
```
[core]
	autocrlf = input
```

Long term it would be great if we weren't using root, which has its own problems. But here we are.

## The Fix:

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

