### PR TITLE
Clean up container after testing for #37

### DIFF
--- a/test/containertest.sh
+++ b/test/containertest.sh
@@ -27,3 +27,4 @@ docker stop web-local-test && docker rm web-local-test
 echo "testing use of custom nginx config"
 docker run -p $HOST_PORT:$CONTAINER_PORT -e "DOCROOT=potato" -v `pwd`/test/test-custom.conf:/var/www/html/.ddev/nginx-site.conf -d --name web-local-test -d `awk '{print $1}' .docker_image`
 docker exec -it web-local-test cat /etc/nginx/sites-enabled/nginx-site.conf | grep "docroot is /var/www/html/potato in custom conf"
+docker stop web-local-test && docker rm web-local-test


### PR DESCRIPTION
## The Problem:

OP #37 - The tests left a container running, occupying a port which was used by a later ddev nightly build test.  It was just a single line left off in the test cleanup.

This doesn't completely solve #37, if there are concerns about the validity of the approach there, they can be taken, or that can be closed after this is done.

## The Fix:

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

