### PR TITLE
Upgrade web container for typo3 (and fixes)

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -39,6 +39,7 @@ RUN apt-get -qq update && \
         libcap2-bin \
         supervisor \
         sudo \
+        imagemagick \
         iputils-ping \
         telnet \
         netcat6 \
@@ -49,8 +50,7 @@ RUN apt-get -qq update && \
 		ncurses-bin \
 		zip \
 		unzip \
-		libpcre3
-RUN	apt-get -qq install --no-install-recommends --no-install-suggests -y \
+		libpcre3 \
         ${PHP_PREFIX}-curl=${PHP_VERSION} \
         ${PHP_PREFIX}-cgi=${PHP_VERSION} \
         ${PHP_PREFIX}-cli=${PHP_VERSION} \
@@ -67,8 +67,8 @@ RUN	apt-get -qq install --no-install-recommends --no-install-suggests -y \
         ${PHP_PREFIX}-soap=${PHP_VERSION} \
         ${PHP_PREFIX}-readline=${PHP_VERSION} \
         ${PHP_PREFIX}-zip=${PHP_VERSION} \
-        php-xdebug=${PHP_XDEBUG_VERSION}
-RUN    apt-get -qq autoremove -y && \
+        php-xdebug=${PHP_XDEBUG_VERSION} && \
+    apt-get -qq autoremove -y && \
     apt-get -qq clean -y && \
 	rm -rf /var/lib/apt/lists/* && \
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -48,7 +48,8 @@ RUN apt-get -qq update && \
 		gettext \
 		ncurses-bin \
 		zip \
-		unzip
+		unzip \
+		libpcre3
 RUN	apt-get -qq install --no-install-recommends --no-install-suggests -y \
         ${PHP_PREFIX}-curl=${PHP_VERSION} \
         ${PHP_PREFIX}-cgi=${PHP_VERSION} \
@@ -65,6 +66,7 @@ RUN	apt-get -qq install --no-install-recommends --no-install-suggests -y \
         ${PHP_PREFIX}-opcache=${PHP_VERSION} \
         ${PHP_PREFIX}-soap=${PHP_VERSION} \
         ${PHP_PREFIX}-readline=${PHP_VERSION} \
+        ${PHP_PREFIX}-zip=${PHP_VERSION} \
         php-xdebug=${PHP_XDEBUG_VERSION}
 RUN    apt-get -qq autoremove -y && \
     apt-get -qq clean -y && \

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -1,15 +1,11 @@
 FROM bitnami/minideb:jessie
 
-ARG PHP_VERSION
-ENV PHP_VERSION=$PHP_VERSION
-ARG NGINX_VERSION
-ENV NGINX_VERSION=$NGINX_VERSION
-ARG DRUSH_VERSION
-ENV DRUSH_VERSION=$DRUSH_VERSION
-ARG WP_CLI_VERSION
-ENV WP_CLI_VERSION=$WP_CLI_VERSION
-ARG MAILHOG_VERSION
-ENV MAILHOG_VERSION=$MAILHOG_VERSION
+ENV PHP_VERSION=7.1
+ENV PHP_PACKAGE=7.1.11-1+0~20171027135825.10+jessie~1.gbp2e638d
+ENV NGINX_VERSION=1.12.1-1~jessie
+ENV DRUSH_VERSION=8.1.15
+ENV WP_CLI_VERSION=1.4.0
+ENV MAILHOG_VERSION=1.0.0
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV TERM xterm
@@ -65,7 +61,7 @@ RUN apt-get -qq update && \
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 ADD "https://github.com/mailhog/MailHog/releases/download/v${MAILHOG_VERSION}/MailHog_linux_amd64" /usr/local/bin/mailhog
-ADD "https://github.com/drush-ops/drush/releases/download/$DRUSH_VERSION/drush.phar" /usr/local/bin/drush
+ADD "https://github.com/drush-ops/drush/releases/download/${DRUSH_VERSION}/drush.phar" /usr/local/bin/drush
 ADD "https://github.com/wp-cli/wp-cli/releases/download/v${WP_CLI_VERSION}/wp-cli-${WP_CLI_VERSION}.phar" /usr/local/bin/wp-cli
 ADD files /
 

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -1,7 +1,8 @@
 FROM bitnami/minideb:jessie
 
-ENV PHP_VERSION=7.1
-ENV PHP_PACKAGE=7.1.11-1+0~20171027135825.10+jessie~1.gbp2e638d
+ENV PHP_PREFIX=php7.1
+ENV PHP_VERSION=7.1.11-1+0~20171027135825.10+jessie~1.gbp2e638d
+ENV PHP_XDEBUG_VERSION=2.5.5-1+0~20170628201550.1+jessie~1.gbp5a1f48
 ENV NGINX_VERSION=1.12.1-1~jessie
 ENV DRUSH_VERSION=8.1.15
 ENV WP_CLI_VERSION=1.4.0
@@ -34,28 +35,38 @@ RUN apt-get -qq update && \
         less \
         git \
         mysql-client \
-        ${PHP_VERSION}-curl \
-        ${PHP_VERSION}-cgi \
-        ${PHP_VERSION}-cli \
-        ${PHP_VERSION}-common \
-        ${PHP_VERSION}-fpm \
-        ${PHP_VERSION}-gd \
-        ${PHP_VERSION}-json \
-        ${PHP_VERSION}-mysql \
-        ${PHP_VERSION}-mbstring \
-        ${PHP_VERSION}-xml \
-        ${PHP_VERSION}-xmlrpc \
-        ${PHP_VERSION}-mcrypt \
-        ${PHP_VERSION}-opcache \
-        ${PHP_VERSION}-soap \
-        ${PHP_VERSION}-readline \
-        ${PHP_VERSION}-xdebug \
         nginx \
         libcap2-bin \
-        supervisor sudo \
-        iputils-ping telnet netcat6 iproute2 \
-        vim nano gettext ncurses-bin zip unzip  && \
-    apt-get -qq autoremove -y && \
+        supervisor \
+        sudo \
+        iputils-ping \
+        telnet \
+        netcat6 \
+        iproute2 \
+		vim \
+		nano \
+		gettext \
+		ncurses-bin \
+		zip \
+		unzip
+RUN	apt-get -qq install --no-install-recommends --no-install-suggests -y \
+        ${PHP_PREFIX}-curl=${PHP_VERSION} \
+        ${PHP_PREFIX}-cgi=${PHP_VERSION} \
+        ${PHP_PREFIX}-cli=${PHP_VERSION} \
+        ${PHP_PREFIX}-common=${PHP_VERSION} \
+        ${PHP_PREFIX}-fpm=${PHP_VERSION} \
+        ${PHP_PREFIX}-gd=${PHP_VERSION} \
+        ${PHP_PREFIX}-json=${PHP_VERSION} \
+        ${PHP_PREFIX}-mysql=${PHP_VERSION} \
+        ${PHP_PREFIX}-mbstring=${PHP_VERSION} \
+        ${PHP_PREFIX}-xml=${PHP_VERSION} \
+        ${PHP_PREFIX}-xmlrpc=${PHP_VERSION} \
+        ${PHP_PREFIX}-mcrypt=${PHP_VERSION} \
+        ${PHP_PREFIX}-opcache=${PHP_VERSION} \
+        ${PHP_PREFIX}-soap=${PHP_VERSION} \
+        ${PHP_PREFIX}-readline=${PHP_VERSION} \
+        php-xdebug=${PHP_XDEBUG_VERSION}
+RUN    apt-get -qq autoremove -y && \
     apt-get -qq clean -y && \
 	rm -rf /var/lib/apt/lists/* && \
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ DOCKER_REPO ?= drud/nginx-php-fpm-local
 #SRC_DIRS := filexs drudapi secrets utils
 
 # Optional to docker build
-DOCKER_ARGS = --build-arg PHP_VERSION=php7.1 --build-arg DRUSH_VERSION=8.1.15 --build-arg NGINX_VERSION=1.12.1-1~jessie --build-arg WP_CLI_VERSION=1.3.0 --build-arg MAILHOG_VERSION=1.0.0
+# DOCKER_ARGS =
 
 # VERSION can be set by
   # Default: git tag

--- a/files/etc/nginx/nginx-site.conf
+++ b/files/etc/nginx/nginx-site.conf
@@ -47,6 +47,8 @@ server {
         fastcgi_index index.php;
         include fastcgi_params;
         fastcgi_intercept_errors on;
+        # fastcgi_read_timeout should match max_execution_time in php.ini
+        fastcgi_read_timeout 240;
         fastcgi_param SERVER_NAME $host;
         fastcgi_param HTTPS $fcgi_https;
     }

--- a/files/etc/php/7.1/fpm/php.ini
+++ b/files/etc/php/7.1/fpm/php.ini
@@ -17,6 +17,7 @@ zend.enable_gc = On
 expose_php = Off
 ; Resource Limits ;
 max_execution_time = 240
+request_terminate_timeout = 240
 max_input_time = 120
 ;max_input_nesting_level = 64
 max_input_vars = 1500

--- a/files/etc/php/7.1/fpm/php.ini
+++ b/files/etc/php/7.1/fpm/php.ini
@@ -16,10 +16,10 @@ disable_classes =
 zend.enable_gc = On
 expose_php = Off
 ; Resource Limits ;
-max_execution_time = 60
+max_execution_time = 240
 max_input_time = 120
 ;max_input_nesting_level = 64
-; max_input_vars = 1000
+max_input_vars = 1500
 memory_limit = 512M
 ; Error handling and logging ;
 error_reporting = E_ALL

--- a/files/etc/php/7.1/mods-available/xdebug.ini
+++ b/files/etc/php/7.1/mods-available/xdebug.ini
@@ -2,4 +2,4 @@ zend_extension=xdebug.so
 xdebug.remote_enable=1
 xdebug.remote_host=172.28.99.99
 xdebug.remote_port=11011
-
+xdebug.max_nesting_level=512


### PR DESCRIPTION
## The Problem:

* Typo3 wants a few random settings and packages (zip. pcre)
* PHP version was not being locked down, so build was unrepeatable
* Moved version specification out of Makefile and into Dockerfile 

For drud/ddev#500: Manually stand up a typo3 site

## The Fix:

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

