### PR TITLE
Stop pinning php to exact version, doesn't work with repo

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -1,8 +1,6 @@
 FROM bitnami/minideb:jessie
 
 ENV PHP_PREFIX=php7.1
-ENV PHP_VERSION=7.1.11-1+0~20171027135825.10+jessie~1.gbp2e638d
-ENV PHP_XDEBUG_VERSION=2.5.5-1+0~20170628201550.1+jessie~1.gbp5a1f48
 ENV NGINX_VERSION=1.12.1-1~jessie
 ENV DRUSH_VERSION=8.1.15
 ENV WP_CLI_VERSION=1.4.0
@@ -51,23 +49,23 @@ RUN apt-get -qq update && \
 		zip \
 		unzip \
 		libpcre3 \
-        ${PHP_PREFIX}-curl=${PHP_VERSION} \
-        ${PHP_PREFIX}-cgi=${PHP_VERSION} \
-        ${PHP_PREFIX}-cli=${PHP_VERSION} \
-        ${PHP_PREFIX}-common=${PHP_VERSION} \
-        ${PHP_PREFIX}-fpm=${PHP_VERSION} \
-        ${PHP_PREFIX}-gd=${PHP_VERSION} \
-        ${PHP_PREFIX}-json=${PHP_VERSION} \
-        ${PHP_PREFIX}-mysql=${PHP_VERSION} \
-        ${PHP_PREFIX}-mbstring=${PHP_VERSION} \
-        ${PHP_PREFIX}-xml=${PHP_VERSION} \
-        ${PHP_PREFIX}-xmlrpc=${PHP_VERSION} \
-        ${PHP_PREFIX}-mcrypt=${PHP_VERSION} \
-        ${PHP_PREFIX}-opcache=${PHP_VERSION} \
-        ${PHP_PREFIX}-soap=${PHP_VERSION} \
-        ${PHP_PREFIX}-readline=${PHP_VERSION} \
-        ${PHP_PREFIX}-zip=${PHP_VERSION} \
-        php-xdebug=${PHP_XDEBUG_VERSION} && \
+        ${PHP_PREFIX}-curl \
+        ${PHP_PREFIX}-cgi \
+        ${PHP_PREFIX}-cli \
+        ${PHP_PREFIX}-common \
+        ${PHP_PREFIX}-fpm \
+        ${PHP_PREFIX}-gd \
+        ${PHP_PREFIX}-json \
+        ${PHP_PREFIX}-mysql \
+        ${PHP_PREFIX}-mbstring \
+        ${PHP_PREFIX}-xml \
+        ${PHP_PREFIX}-xmlrpc \
+        ${PHP_PREFIX}-mcrypt \
+        ${PHP_PREFIX}-opcache \
+        ${PHP_PREFIX}-soap \
+        ${PHP_PREFIX}-readline \
+        ${PHP_PREFIX}-zip \
+        php-xdebug && \
     apt-get -qq autoremove -y && \
     apt-get -qq clean -y && \
 	rm -rf /var/lib/apt/lists/* && \


### PR DESCRIPTION
## The Problem:

ddev nightly builds (which build all necessary containers from submodules) broke last night because of the unavailability of the explicitly named exact php version I added in #41. The intent was to have a completely reproducible build, but I guess if the repo isn't going to provide the exact version, we're not going to have a totally reproducible build. 

This needs to go in to fix the ddev nightly.

## The Fix:

Bail on explicit versioning for php7.1 and php-xdebug.

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:

After this goes in:
- [ ] Create a new docker.nginx-php-fpm-local release v0.8.2
- [ ] Push the new docker container (git fetch upstream; git checkout upstream/master; make push)
- [ ] New PR for ddev that uses WebTag ?= v0.8.2 (in Makefile)

Just getting it in will fix the nightly, but we need to follow up with these anyway.