### PR TITLE
php 5.6 mbstring options required for drupal6 install

### DIFF
--- a/files/etc/php/5.6/fpm/php.ini
+++ b/files/etc/php/5.6/fpm/php.ini
@@ -61,6 +61,11 @@ default_socket_timeout = 60
 ;auto_detect_line_endings = Off
 ; Dynamic Extensions ;
 
+[mbstring]
+; Required for drupal6
+mbstring.http_output = pass
+mbstring.http_input = pass
+
 [CLI Server]
 cli_server.color = On
 


### PR DESCRIPTION
## The Problem:

php 5.6 deprecated the mbstring.http_output and mbstring.http_input. However, drupal continued to rely on those for validation at install time, into drupal7 and even drupal8. This problem was fixed in drupal7 and drupal8 but never in drupal6.

The d6lts issue is https://www.drupal.org/project/d6lts/issues/2332295
The original drupal 4.6 issue is https://www.drupal.org/project/drupal/issues/87138

## The Fix:

For php 5.6 only, set 
```
mbstring.http_output = pass
mbstring.http_input = pass
```

AFAICT this is just window dressing, affects no behavior, and is there for D6 only.

## The Test:

Probably just do a plain drupal 6.38 install using https://github.com/drud/ddev/pull/595 - note that the container tag must be set to the container tag there, so if you're re-config-ging a project, you'll have to check that.

## Automation Overview:

No changes.

## Related Issue Link(s):

The ddev issue is https://github.com/drud/ddev/pull/595 - setting up drupal 6.

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

After this is pulled we need 
- [ ] a new minor release
- [ ] ddev PR has to be updated with the new tag
