### PR TITLE
Web container maintenance: php 7.2, drupal-composer, backdrop drush, fixes #39

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -63,6 +63,8 @@ RUN curl -sSL "https://github.com/mailhog/MailHog/releases/download/v${MAILHOG_V
 RUN curl -sSL "https://github.com/wp-cli/wp-cli/releases/download/v${WP_CLI_VERSION}/wp-cli-${WP_CLI_VERSION}.phar" -o /usr/local/bin/wp-cli
 RUN composer global require drush/drush:${DRUSH_VERSION} && ln -s /root/.composer/vendor/bin/drush /usr/local/bin/drush
 
+RUN curl https://drupalconsole.com/installer -L -o /usr/local/bin/drupal && chmod +x /usr/local/bin/drupal
+
 ADD files /
 
 RUN mkdir -p /etc/nginx/sites-enabled && \

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -8,6 +8,7 @@ ENV NGINX_VERSION=1.12.1-1~jessie
 ENV DRUSH_VERSION=8.1.15
 ENV WP_CLI_VERSION=1.4.1
 ENV MAILHOG_VERSION=1.0.0
+ENV BACKDROP_DRUSH_VERSION=0.0.6
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV TERM xterm
@@ -62,9 +63,11 @@ RUN curl -sSL "https://github.com/mailhog/MailHog/releases/download/v${MAILHOG_V
 RUN curl -sSL "https://github.com/wp-cli/wp-cli/releases/download/v${WP_CLI_VERSION}/wp-cli-${WP_CLI_VERSION}.phar" -o /usr/local/bin/wp-cli
 RUN composer global require drush/drush:${DRUSH_VERSION} && ln -s /root/.composer/vendor/bin/drush /usr/local/bin/drush
 
-RUN curl https://drupalconsole.com/installer -L -o /usr/local/bin/drupal && chmod +x /usr/local/bin/drupal
+RUN curl -sSL "https://drupalconsole.com/installer" -L -o /usr/local/bin/drupal && chmod +x /usr/local/bin/drupal
 
 ADD files /
+
+RUN curl -sSL https://github.com/backdrop-contrib/drush/releases/download/${BACKDROP_DRUSH_VERSION}/drush.zip -o /tmp/backdrop_drush.zip && unzip /tmp/backdrop_drush.zip -d ~/backdrop_drush_commands
 
 RUN mkdir -p /etc/nginx/sites-enabled && \
     touch /var/log/php-fpm.log && \

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -1,6 +1,6 @@
 FROM bitnami/minideb:jessie
 
-ENV PHP_VERSIONS="5.6 7.0 7.1"
+ENV PHP_VERSIONS="5.6 7.0 7.1 7.2"
 ENV PHP_DEFAULT_VERSION="7.1"
 ENV PHP_INI=/etc/php/$PHP_DEFAULT_VERSION/fpm/php.ini
 
@@ -51,9 +51,8 @@ RUN apt-get -qq update && \
 		zip \
 		unzip \
 		libpcre3 && \
-	for v in php${PHP_VERSIONS}; do apt-get -qq install --no-install-recommends --no-install-suggests -y $v-curl $v-cgi $v-cli $v-common $v-fpm $v-gd $v-intl $v-json $v-mysql $v-mbstring  $v-opcache $v-soap $v-readline $v-xml $v-xmlrpc $v-zip; done && \
+	for v in php${PHP_VERSIONS}; do apt-get -qq install --no-install-recommends --no-install-suggests -y $v-curl $v-cgi $v-cli $v-common $v-fpm $v-gd $v-intl $v-json $v-mysql $v-mbstring  $v-opcache $v-soap $v-readline $v-xdebug $v-xml $v-xmlrpc $v-zip; done && \
 	for v in php5.6 php7.0 php7.1; do apt-get -qq install --no-install-recommends --no-install-suggests -y $v-mcrypt; done && \
-	apt-get -qq install --no-install-recommends --no-install-suggests -y php-xdebug && \
     apt-get -qq autoremove -y && \
     apt-get -qq clean -y && \
 	rm -rf /var/lib/apt/lists/* && \

--- a/files/etc/php/7.0/fpm/php-fpm.conf
+++ b/files/etc/php/7.0/fpm/php-fpm.conf
@@ -122,4 +122,4 @@ daemonize = no
 ; Relative path can also be used. They will be prefixed by:
 ;  - the global prefix if it's been set (-p argument)
 ;  - /usr otherwise
-include = /etc/php/7.1/fpm/pool.d/*.conf
+include = /etc/php/7.0/fpm/pool.d/*.conf

--- a/files/etc/php/7.2/fpm/php-fpm.conf
+++ b/files/etc/php/7.2/fpm/php-fpm.conf
@@ -122,4 +122,4 @@ daemonize = no
 ; Relative path can also be used. They will be prefixed by:
 ;  - the global prefix if it's been set (-p argument)
 ;  - /usr otherwise
-include = /etc/php/7.1/fpm/pool.d/*.conf
+include = /etc/php/7.2/fpm/pool.d/*.conf

--- a/files/start.sh
+++ b/files/start.sh
@@ -37,9 +37,9 @@ chown -R nginx:nginx /var/log/nginx
 
 # Display PHP errors or not
 if [[ "$ERRORS" != "1" ]] ; then
- echo php_flag[display_errors] = off >> /etc/php/7.1/fpm/php-fpm.conf
+ echo php_flag[display_errors] = off >> /etc/php/$DDEV_PHP_VERSION/fpm/php-fpm.conf
 else
- echo php_flag[display_errors] = on >> /etc/php/7.1/fpm/php-fpm.conf
+ echo php_flag[display_errors] = on >> /etc/php/$DDEV_PHP_VERSION/fpm/php-fpm.conf
 fi
 
 /usr/bin/supervisord -c /etc/supervisord.conf

--- a/files/start.sh
+++ b/files/start.sh
@@ -19,6 +19,10 @@ if [ -n "$DDEV_PHP_VERSION" ] ; then
 	export PHP_INI=/etc/php/${DDEV_PHP_VERSION}/fpm/php.ini
 fi
 
+if [ "$DDEV_PROJECT_TYPE" = "backdrop" ] ; then
+	mkdir -p ~/.drush/commands && ln -s ~/backdrop_drush_commands ~/.drush/commands/backdrop
+fi
+
 # Substitute values of environment variables in nginx configuration
 envsubst "$NGINX_SITE_VARS" < "$NGINX_SITE_TEMPLATE" > /etc/nginx/sites-enabled/nginx-site.conf
 

--- a/files/start.sh
+++ b/files/start.sh
@@ -3,7 +3,7 @@ set -x
 set -o errexit nounset pipefail
 
 # If DDEV_PHP_VERSION isn't set, use a reasonable default
-DDEV_PHP_VERSION?=${DDEV_PHP_VERSION:-$PHP_DEFAULT_VERSION}
+DDEV_PHP_VERSION=${DDEV_PHP_VERSION:-$PHP_DEFAULT_VERSION}
 
 # Update full path NGINX_DOCROOT if DOCROOT env is provided
 if [ -n "$DOCROOT" ] ; then

--- a/files/start.sh
+++ b/files/start.sh
@@ -2,6 +2,9 @@
 set -x
 set -o errexit nounset pipefail
 
+# If DDEV_PHP_VERSION isn't set, use a reasonable default
+DDEV_PHP_VERSION?=${DDEV_PHP_VERSION:-$PHP_DEFAULT_VERSION}
+
 # Update full path NGINX_DOCROOT if DOCROOT env is provided
 if [ -n "$DOCROOT" ] ; then
     export NGINX_DOCROOT="/var/www/html/$DOCROOT"

--- a/test/containertest.sh
+++ b/test/containertest.sh
@@ -18,7 +18,7 @@ trap cleanup EXIT
 
 cleanup
 
-for v in 5.6 7.0 7.1; do
+for v in 5.6 7.0 7.1 7.2; do
 	echo "starting container for tests"
 	CONTAINER=$(docker run -p $HOST_PORT:$CONTAINER_PORT -e "DOCROOT=docroot" -e "DDEV_PHP_VERSION=$v" -d --name $CONTAINER_NAME -d $DOCKER_IMAGE)
 	./test/containercheck.sh

--- a/test/containertest.sh
+++ b/test/containertest.sh
@@ -19,7 +19,7 @@ trap cleanup EXIT
 cleanup
 
 for v in 5.6 7.0 7.1 7.2; do
-	echo "starting container for tests"
+	echo "starting container for tests on php$v"
 	CONTAINER=$(docker run -p $HOST_PORT:$CONTAINER_PORT -e "DOCROOT=docroot" -e "DDEV_PHP_VERSION=$v" -d --name $CONTAINER_NAME -d $DOCKER_IMAGE)
 	./test/containercheck.sh
 	curl --fail localhost:$HOST_PORT/test/phptest.php
@@ -28,7 +28,7 @@ for v in 5.6 7.0 7.1 7.2; do
 	docker exec -it $CONTAINER drush --version
 	docker exec -it $CONTAINER wp --version
 
-	echo "testing error states"
+	echo "testing error states for php$v"
 	# These are just the standard nginx 403 and 404 pages
 	curl localhost:$HOST_PORT/ | grep "403 Forbidden"
 	curl localhost:$HOST_PORT/asdf | grep "404 Not Found"
@@ -39,7 +39,7 @@ for v in 5.6 7.0 7.1 7.2; do
 	curl localhost:$HOST_PORT/test/400.php | grep "ddev web container.*400"
 	curl localhost:$HOST_PORT/test/401.php | grep "ddev web container.*401"
 
-	echo "testing php and email"
+	echo "testing php and email for php$v"
 	curl --fail localhost:$HOST_PORT/test/phptest.php
 	curl -s localhost:$HOST_PORT/test/test-email.php | grep "Test email sent"
 


### PR DESCRIPTION
## The Problem:

We have a backlog of maintenance on this, described in #39. Need to add:

* drupal-console
* php7.2 now that xdebug works with it.
* drush versions for use by backdrop
* Backdrop extra libraries

## The Fix:

* Add drupal-console launcher to /usr/local/bin/drupal
* Add php7.2 with xdebug support
* Incorporate $DDEV_PROJECT_TYPE so container can detect backdrop and add drush commands.
* Minor fixups for php7.2 and add on to testing.

## Manual Test:

This is currently pushed as drud/nginx-php-fpm-local:20180214_backdrop_drush

It's easiest to test this with https://github.com/drud/ddev/pull/651 - but remember you need to delete docker-compose.yml and config.yaml

- [ ] Try out php 7.2, especially with xdebug
- [ ] Test php 5.6 with xdebug
- [ ] Test TYPO3 v9 install with php 7.2
- [ ] Test backdrop drush usage

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:

- [ ] After this is pulled, we have to create a release
- [ ] Then push the docker image
