### PR TITLE
Add php bcmath extension, fixes drud/ddev#655

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -52,7 +52,7 @@ RUN apt-get -qq update && \
 		zip \
 		unzip \
 		libpcre3 && \
-	for v in php${PHP_VERSIONS}; do apt-get -qq install --no-install-recommends --no-install-suggests -y $v-curl $v-cgi $v-cli $v-common $v-fpm $v-gd $v-intl $v-json $v-mysql $v-mbstring  $v-opcache $v-soap $v-readline $v-xdebug $v-xml $v-xmlrpc $v-zip; done && \
+	for v in php${PHP_VERSIONS}; do apt-get -qq install --no-install-recommends --no-install-suggests -y $v-bcmath $v-curl $v-cgi $v-cli $v-common $v-fpm $v-gd $v-intl $v-json $v-mysql $v-mbstring  $v-opcache $v-soap $v-readline $v-xdebug $v-xml $v-xmlrpc $v-zip; done && \
 	for v in php5.6 php7.0 php7.1; do apt-get -qq install --no-install-recommends --no-install-suggests -y $v-mcrypt; done && \
     apt-get -qq autoremove -y && \
     apt-get -qq clean -y && \


### PR DESCRIPTION
## The Problem:

Drupal commerce requires php-bcmath, and it's easy to add. 

## The Fix:

Add it.

## The Test:

Use this container in your .ddev/config.yaml. Use any technique you like (admin/reports/status/php in a drupal site) to verify that bcmath is available. For extra credit, install drupal commerce.

This is pushed as drud/nginx-php-fpm-local:20180219_add_php_bcmath - it can be used immediately by changing config.yaml with
```
webimage: drud/nginx-php-fpm-local:20180219_add_php_bcmath
```
and `ddev start`

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

OP: drud/ddev#655

## Release/Deployment notes:

- [ ] Create a release and push new version
- [ ] Add ddev PR to bump to the new version
