### PR TITLE
Quiet healthcheck logs, tail both fpm and nginx PULL on 2018-03-06 #TRIVIALREVIEW

### DIFF
--- a/files/etc/nginx/nginx-site-backdrop.conf
+++ b/files/etc/nginx/nginx-site-backdrop.conf
@@ -100,6 +100,8 @@ server {
     ## provide a health check endpoint
     location /healthcheck {
         access_log off;
+        stub_status     on;
+        keepalive_timeout 0;    # Disable HTTP keepalive
         return 200;
     }
 

--- a/files/etc/nginx/nginx-site-default.conf
+++ b/files/etc/nginx/nginx-site-default.conf
@@ -100,6 +100,8 @@ server {
     ## provide a health check endpoint
     location /healthcheck {
         access_log off;
+        stub_status     on;
+        keepalive_timeout 0;    # Disable HTTP keepalive
         return 200;
     }
 

--- a/files/etc/nginx/nginx-site-drupal6.conf
+++ b/files/etc/nginx/nginx-site-drupal6.conf
@@ -100,6 +100,8 @@ server {
     ## provide a health check endpoint
     location /healthcheck {
         access_log off;
+        stub_status     on;
+        keepalive_timeout 0;    # Disable HTTP keepalive
         return 200;
     }
 

--- a/files/etc/nginx/nginx-site-drupal7.conf
+++ b/files/etc/nginx/nginx-site-drupal7.conf
@@ -102,6 +102,8 @@ server {
     ## provide a health check endpoint
     location /healthcheck {
         access_log off;
+        stub_status     on;
+        keepalive_timeout 0;    # Disable HTTP keepalive
         return 200;
     }
 

--- a/files/etc/nginx/nginx-site-drupal8.conf
+++ b/files/etc/nginx/nginx-site-drupal8.conf
@@ -100,6 +100,8 @@ server {
     ## provide a health check endpoint
     location /healthcheck {
         access_log off;
+        stub_status     on;
+        keepalive_timeout 0;    # Disable HTTP keepalive
         return 200;
     }
 

--- a/files/etc/nginx/nginx-site-typo3.conf
+++ b/files/etc/nginx/nginx-site-typo3.conf
@@ -78,6 +78,8 @@ server {
     ## provide a health check endpoint
     location /healthcheck {
         access_log off;
+        stub_status     on;
+        keepalive_timeout 0;    # Disable HTTP keepalive
         return 200;
     }
 

--- a/files/etc/nginx/nginx-site-wordpress.conf
+++ b/files/etc/nginx/nginx-site-wordpress.conf
@@ -90,6 +90,8 @@ server {
     ## provide a health check endpoint
     location /healthcheck {
         access_log off;
+        stub_status     on;
+        keepalive_timeout 0;    # Disable HTTP keepalive
         return 200;
     }
 

--- a/files/start.sh
+++ b/files/start.sh
@@ -57,4 +57,4 @@ fi
 /usr/bin/supervisord -c /etc/supervisord.conf
 
 echo 'Server started'
-tail -f /var/log/nginx/error.log
+tail -f /var/log/nginx/error.log /var/log/php-fpm.log

--- a/test/containertest.sh
+++ b/test/containertest.sh
@@ -64,6 +64,12 @@ for project_type in drupal6 drupal7 drupal8 typo3 backdrop wordpress default; do
 	# Only drupal6 is currently different here.
 	docker exec -it $CONTAINER php --version | grep "PHP $PHP_VERSION"
 
+	# Make sure we don't have lots of "closed keepalive connection" complaints
+	docker logs $CONTAINER | grep -v "closed keepalive connection"
+	# Make sure both nginx logs and fpm logs are being tailed
+	docker logs $CONTAINER | grep "==> /var/log/nginx/error.log" >/dev/null
+	docker logs $CONTAINER | grep "==> /var/log/php-fpm.log" >/dev/null
+
 	# Make sure that backdrop drush commands were added on backdrop and only backdrop
 	if [ "$project_type" == "backdrop" ] ; then
 	 	# The .drush/commands/backdrop directory should only exist for backdrop apptype


### PR DESCRIPTION
## The Problem:

https://github.com/drud/ddev/issues/494 points out that there's way lots of noise in the `ddev logs`, so much that you can't see anything important.

https://stackoverflow.com/a/24939287/215713 points out that we can just quiet it with a couple of lines of nginx, so that's done here.

In addition, this adds tailing both the fpm and nginx logs.

OP drud/ddev#494

You can test this by using `webimage: drud/nginx-php-fpm-local:20180228_quiet_keepalive` with ddev.