### PR TITLE
Don't use database section for .my.cnf, for drud/mariadb-local#43 #TRIVIALREVIEW

### DIFF
--- a/files/root/.my.cnf
+++ b/files/root/.my.cnf
@@ -1,5 +1,7 @@
 [client]
 user=db
 password=db
-database=db
 host=db
+
+[mysql]
+database=db


### PR DESCRIPTION
## The Problem:

OP drud/mariadb-local#43:  mysqldump and drush sql-dump output ugly warnings, the fix is shown in the OP.

## The Fix:

## The Test:

ddev ssh into this container, or use docker run -it, and do a mysqldump.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

