### PR TITLE
Add bzip2 and fontconfig in support of drupal8 testing (phantomjs) for drud/ddev#723

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -25,7 +25,9 @@ RUN apt-get -qq update && \
         curl \
         ca-certificates \
         apt-transport-https \
-        wget && \
+        wget \
+        fontconfig \
+        bzip2 && \
     wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg && \
     echo "deb https://packages.sury.org/php/ jessie main" > /etc/apt/sources.list.d/php.list && \
     wget -q -O /tmp/nginx_signing.key http://nginx.org/keys/nginx_signing.key && \


### PR DESCRIPTION
## The Problem:

D8 testing requires phantomjs, which requires fontconfig and bzip2 (just to unarchive). Add those.

phantomjs is a larger thing, and we need to think about what to do for that. It doesn't seem right to add it to the container directly, so we'll keep thinking about that.

OP drud/ddev#723 requesting Drupal8 test support.

## The Fix:

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

