### PR TITLE
Stop composer from screaming about running as root, fixes drud/ddev#734

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -16,6 +16,10 @@ ENV MH_SMTP_BIND_ADDR 127.0.0.1:1025
 ENV PATH="/root/.composer/vendor/bin:$PATH"
 ENV NGINX_SITE_TEMPLATE /etc/nginx/nginx-site.conf
 ENV NGINX_DOCROOT /var/www/html
+
+# composer normally screams about running as root, we don't need that.
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
 # Defines vars in colon-separated notation to be subsituted with values for NGINX_SITE_TEMPLATE on start
 ENV NGINX_SITE_VARS '$NGINX_DOCROOT'
 


### PR DESCRIPTION
## The Problem:

composer normally warns quite strongly about superuser, see OP drud/ddev#734, but we don't need it to scream and it scares people. 

This is pushed temporarily as drud/nginx-php-fpm-local:20180316_composer_allow_superuser

## The Fix:

Quiet it with COMPOSER_ALLOW_SUPERUSER=1

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

