### PR TITLE
Web container pre-release fixups: logging

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -92,14 +92,12 @@ RUN mkdir -p /etc/nginx/sites-enabled && \
 
 RUN chmod -R 777 /var/log
 
-# Experimental, better to have dedicated directories instead
 RUN chmod -R ugo+w /usr/sbin /usr/bin /etc/nginx /var/cache/nginx /run /var/www/html /etc/php/*/*/conf.d/ /var/lib/php/modules /etc/alternatives
 # All users will have their home directory in /home, make it fully writeable
 RUN mkdir -p /home/.composer /home/.drush/commands && chmod 777 /home && chmod -R ugo+w /home/.composer /home/.drush
 
-RUN touch /var/log/nginx/error.log /var/log/php-fpm.log && chmod ugo+rw /var/log/nginx/error.log /var/log/php-fpm.log
+RUN touch /var/log/nginx/error.log /var/log/nginx/access.log /var/log/php-fpm.log && chmod ugo+rw /var/log/nginx/error.log /var/log/nginx/access.log /var/log/php-fpm.log
 
-VOLUME /var/log/nginx
 EXPOSE 8080 8025
 HEALTHCHECK --interval=2s --retries=5 CMD ["/healthcheck.sh"]
 

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -100,6 +100,6 @@ RUN touch /var/log/nginx/error.log /var/log/nginx/access.log /var/log/php-fpm.lo
   chmod 666 /var/log/nginx/error.log /var/log/nginx/access.log /var/log/php-fpm.log
 
 EXPOSE 8080 8025
-HEALTHCHECK --interval=5m --timeout=3s --retries=3 CMD ["/healthcheck.sh"]
+HEALTHCHECK --interval=2s --retries=5 CMD ["/healthcheck.sh"]
 
 CMD ["/start.sh"]

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -100,6 +100,6 @@ RUN touch /var/log/nginx/error.log /var/log/nginx/access.log /var/log/php-fpm.lo
   chmod 666 /var/log/nginx/error.log /var/log/nginx/access.log /var/log/php-fpm.log
 
 EXPOSE 8080 8025
-HEALTHCHECK --interval=2s --retries=5 CMD ["/healthcheck.sh"]
+HEALTHCHECK --interval=10s --retries=3 CMD ["/healthcheck.sh"]
 
 CMD ["/start.sh"]

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -100,6 +100,6 @@ RUN touch /var/log/nginx/error.log /var/log/nginx/access.log /var/log/php-fpm.lo
   chmod 666 /var/log/nginx/error.log /var/log/nginx/access.log /var/log/php-fpm.log
 
 EXPOSE 8080 8025
-HEALTHCHECK --interval=10s --retries=3 CMD ["/healthcheck.sh"]
+HEALTHCHECK --interval=5m --timeout=3s --retries=3 CMD ["/healthcheck.sh"]
 
 CMD ["/start.sh"]

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -96,7 +96,8 @@ RUN chmod -R ugo+w /usr/sbin /usr/bin /etc/nginx /var/cache/nginx /run /var/www/
 # All users will have their home directory in /home, make it fully writeable
 RUN mkdir -p /home/.composer /home/.drush/commands && chmod 777 /home && chmod -R ugo+w /home/.composer /home/.drush
 
-RUN touch /var/log/nginx/error.log /var/log/nginx/access.log /var/log/php-fpm.log && chmod ugo+rw /var/log/nginx/error.log /var/log/nginx/access.log /var/log/php-fpm.log
+RUN touch /var/log/nginx/error.log /var/log/nginx/access.log /var/log/php-fpm.log && \
+  chmod 666 /var/log/nginx/error.log /var/log/nginx/access.log /var/log/php-fpm.log
 
 EXPOSE 8080 8025
 HEALTHCHECK --interval=2s --retries=5 CMD ["/healthcheck.sh"]

--- a/files/etc/nginx/nginx-site-backdrop.conf
+++ b/files/etc/nginx/nginx-site-backdrop.conf
@@ -24,7 +24,7 @@ server {
     # Disable sendfile as per https://docs.vagrantup.com/v2/synced-folders/virtualbox.html
     sendfile off;
     error_log /var/log/nginx/error.log info;
-    access_log /var/log/nginx/error.log;
+    access_log /var/log/nginx/access.log;
 
     location / {
         try_files $uri /index.php?$query_string; # For Drupal >= 7

--- a/files/etc/nginx/nginx-site-backdrop.conf
+++ b/files/etc/nginx/nginx-site-backdrop.conf
@@ -112,6 +112,8 @@ server {
 
     location ~ ^/(fpmstatus|ping)$ {
         access_log off;
+        stub_status     on;
+        keepalive_timeout 0;    # Disable HTTP keepalive
         allow 127.0.0.1;
         allow all;
         fastcgi_index index.php;

--- a/files/etc/nginx/nginx-site-default.conf
+++ b/files/etc/nginx/nginx-site-default.conf
@@ -24,7 +24,7 @@ server {
     # Disable sendfile as per https://docs.vagrantup.com/v2/synced-folders/virtualbox.html
     sendfile off;
     error_log /var/log/nginx/error.log info;
-    access_log /var/log/nginx/error.log;
+    access_log /var/log/nginx/access.log;
 
     location / {
         try_files $uri $uri/ /index.php?q=$uri&$args;

--- a/files/etc/nginx/nginx-site-default.conf
+++ b/files/etc/nginx/nginx-site-default.conf
@@ -112,6 +112,8 @@ server {
 
     location ~ ^/(fpmstatus|ping)$ {
         access_log off;
+        stub_status     on;
+        keepalive_timeout 0;    # Disable HTTP keepalive
         allow 127.0.0.1;
         allow all;
         fastcgi_index index.php;

--- a/files/etc/nginx/nginx-site-drupal6.conf
+++ b/files/etc/nginx/nginx-site-drupal6.conf
@@ -111,13 +111,15 @@ server {
     }
 
     location ~ ^/(fpmstatus|ping)$ {
-         access_log off;
-         allow 127.0.0.1;
-         allow all;
-         fastcgi_index index.php;
-         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-         include fastcgi_params;
-         fastcgi_pass unix:/run/php-fpm.sock;
+        access_log off;
+        stub_status     on;
+        keepalive_timeout 0;    # Disable HTTP keepalive
+        allow 127.0.0.1;
+        allow all;
+        fastcgi_index index.php;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        include fastcgi_params;
+        fastcgi_pass unix:/run/php-fpm.sock;
     }
 
 }

--- a/files/etc/nginx/nginx-site-drupal6.conf
+++ b/files/etc/nginx/nginx-site-drupal6.conf
@@ -34,7 +34,7 @@ server {
     # Disable sendfile as per https://docs.vagrantup.com/v2/synced-folders/virtualbox.html
     sendfile off;
     error_log /var/log/nginx/error.log info;
-    access_log /var/log/nginx/error.log;
+    access_log /var/log/nginx/access.log;
 
     location / {
         try_files $uri /index.php?q=$no_slash_uri&$args;

--- a/files/etc/nginx/nginx-site-drupal7.conf
+++ b/files/etc/nginx/nginx-site-drupal7.conf
@@ -24,7 +24,7 @@ server {
     # Disable sendfile as per https://docs.vagrantup.com/v2/synced-folders/virtualbox.html
     sendfile off;
     error_log /var/log/nginx/error.log info;
-    access_log /var/log/nginx/error.log;
+    access_log /var/log/nginx/access.log;
 
     location / {
         # First attempt to serve request as file, then

--- a/files/etc/nginx/nginx-site-drupal7.conf
+++ b/files/etc/nginx/nginx-site-drupal7.conf
@@ -114,6 +114,8 @@ server {
 
     location ~ ^/(fpmstatus|ping)$ {
          access_log off;
+         stub_status     on;
+         keepalive_timeout 0;    # Disable HTTP keepalive
          allow 127.0.0.1;
          allow all;
          fastcgi_index index.php;

--- a/files/etc/nginx/nginx-site-drupal8.conf
+++ b/files/etc/nginx/nginx-site-drupal8.conf
@@ -24,7 +24,7 @@ server {
     # Disable sendfile as per https://docs.vagrantup.com/v2/synced-folders/virtualbox.html
     sendfile off;
     error_log /var/log/nginx/error.log info;
-    access_log /var/log/nginx/error.log;
+    access_log /var/log/nginx/access.log;
 
     location / {
         try_files $uri /index.php?$query_string; # For Drupal >= 7

--- a/files/etc/nginx/nginx-site-drupal8.conf
+++ b/files/etc/nginx/nginx-site-drupal8.conf
@@ -112,6 +112,8 @@ server {
 
     location ~ ^/(fpmstatus|ping)$ {
          access_log off;
+         stub_status     on;
+         keepalive_timeout 0;    # Disable HTTP keepalive
          allow 127.0.0.1;
          allow all;
          fastcgi_index index.php;

--- a/files/etc/nginx/nginx-site-typo3.conf
+++ b/files/etc/nginx/nginx-site-typo3.conf
@@ -24,7 +24,7 @@ server {
     # Disable sendfile as per https://docs.vagrantup.com/v2/synced-folders/virtualbox.html
     sendfile off;
     error_log /var/log/nginx/error.log info;
-    access_log /var/log/nginx/error.log;
+    access_log /var/log/nginx/access.log;
 
     location / {
         try_files $uri $uri/ /index.php$is_args$args;

--- a/files/etc/nginx/nginx-site-typo3.conf
+++ b/files/etc/nginx/nginx-site-typo3.conf
@@ -141,6 +141,8 @@ server {
 
     location ~ ^/(fpmstatus|ping)$ {
          access_log off;
+         stub_status     on;
+         keepalive_timeout 0;    # Disable HTTP keepalive
          allow 127.0.0.1;
          allow all;
          fastcgi_index index.php;

--- a/files/etc/nginx/nginx-site-wordpress.conf
+++ b/files/etc/nginx/nginx-site-wordpress.conf
@@ -29,7 +29,7 @@ server {
     # Disable sendfile as per https://docs.vagrantup.com/v2/synced-folders/virtualbox.html
     sendfile off;
     error_log /var/log/nginx/error.log info;
-    access_log /var/log/nginx/error.log;
+    access_log /var/log/nginx/access.log;
 
     # From wordpress demo global_restrictions.conf
     # Global restrictions configuration file.

--- a/files/etc/nginx/nginx-site-wordpress.conf
+++ b/files/etc/nginx/nginx-site-wordpress.conf
@@ -102,6 +102,8 @@ server {
 
     location ~ ^/(fpmstatus|ping)$ {
          access_log off;
+         stub_status     on;
+         keepalive_timeout 0;    # Disable HTTP keepalive
          allow 127.0.0.1;
          allow all;
          fastcgi_index index.php;

--- a/files/etc/php/5.6/fpm/php-fpm.conf
+++ b/files/etc/php/5.6/fpm/php-fpm.conf
@@ -21,7 +21,8 @@ pid = /run/php-fpm.pid
 ; in a local file.
 ; Note: the default prefix is /var
 ; Default Value: log/php-fpm.log
-error_log = /var/log/php-fpm.log
+; Output to stdout, where supervisord will manage it.
+error_log = /proc/self/fd/2
 
 ; syslog_facility is used to specify what type of program is logging the
 ; message. This lets syslogd specify that messages from different facilities

--- a/files/etc/php/7.0/fpm/php-fpm.conf
+++ b/files/etc/php/7.0/fpm/php-fpm.conf
@@ -21,7 +21,8 @@ pid = /run/php-fpm.pid
 ; in a local file.
 ; Note: the default prefix is /var
 ; Default Value: log/php-fpm.log
-error_log = /var/log/php-fpm.log
+; Output to stdout, where supervisord will manage it.
+error_log = /proc/self/fd/2
 
 ; syslog_facility is used to specify what type of program is logging the
 ; message. This lets syslogd specify that messages from different facilities

--- a/files/etc/php/7.1/fpm/php-fpm.conf
+++ b/files/etc/php/7.1/fpm/php-fpm.conf
@@ -21,7 +21,8 @@ pid = /run/php-fpm.pid
 ; in a local file.
 ; Note: the default prefix is /var
 ; Default Value: log/php-fpm.log
-error_log = /var/log/php-fpm.log
+; Output to stdout, where supervisord will manage it.
+error_log = /proc/self/fd/2
 
 ; syslog_facility is used to specify what type of program is logging the
 ; message. This lets syslogd specify that messages from different facilities

--- a/files/etc/php/7.2/fpm/php-fpm.conf
+++ b/files/etc/php/7.2/fpm/php-fpm.conf
@@ -21,7 +21,8 @@ pid = /run/php-fpm.pid
 ; in a local file.
 ; Note: the default prefix is /var
 ; Default Value: log/php-fpm.log
-error_log = /var/log/php-fpm.log
+; Output to stdout, where supervisord will manage it.
+error_log = /proc/self/fd/2
 
 ; syslog_facility is used to specify what type of program is logging the
 ; message. This lets syslogd specify that messages from different facilities

--- a/files/etc/supervisord.conf
+++ b/files/etc/supervisord.conf
@@ -26,9 +26,9 @@ command = /usr/sbin/php-fpm -R
 autostart=true
 autorestart=true
 priority=5
-stdout_logfile=/var/log/nginx/access.log
+stdout_logfile=/var/log/php-fpm.log
 stdout_logfile_maxbytes=0
-stderr_logfile=/var/log/nginx/error.log
+stderr_logfile=/var/log/php-fpm.log
 stderr_logfile_maxbytes=0
 
 [program:nginx]

--- a/files/etc/supervisord.conf
+++ b/files/etc/supervisord.conf
@@ -53,3 +53,12 @@ redirect_stderr=true
 stdout_logfile=/var/log/mailhog.log
 stdout_logfile_maxbytes=50MB
 stdout_logfile_backups=10
+
+[program:tail]
+command=/usr/bin/tail -f /var/log/nginx/error.log /var/log/php-fpm.log
+autostart=true
+autorestart=true
+priority=30
+startretries=10
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0

--- a/files/healthcheck.sh
+++ b/files/healthcheck.sh
@@ -5,5 +5,4 @@
 set -eo pipefail
 
 curl --fail localhost:8080/fpmstatus
-curl --fail localhost:8080/healthcheck/
 curl --fail localhost:8025 >/dev/null 2>&1

--- a/files/start.sh
+++ b/files/start.sh
@@ -53,7 +53,6 @@ envsubst "$NGINX_SITE_VARS" < "$NGINX_SITE_TEMPLATE" > /etc/nginx/sites-enabled/
 # Disable xdebug by default. Users can enable with /usr/local/bin/enable_xdebug
 disable_xdebug
 
-tail -f /var/log/nginx/error.log /var/log/php-fpm.log &
 echo 'Server started'
 
 exec /usr/bin/supervisord -n -c /etc/supervisord.conf


### PR DESCRIPTION
## The Problem:

On Linux with Docker 18.03.0 stable the logging was failing, apparently due to the VOLUME command that overrode all permissions settings. 

## The Fix:

* Remove the VOLUME command
* Adjust permissions
* Move the tail out of start.sh and into supervisord.conf
* Adjust healthcheck
* Move the nginx access log output to access.log instead of error.log

This is pushed as drud/nginx-php-fpm-local:20180327_no_volume

This is destined to be v1.2.1 tag

## Manual testing:

It can be tested by changing the config.yaml  to `webimage:drud/nginx-php-fpm-local:20180327_no_volume` and use https://github.com/drud/ddev/pull/745

Test with normal start and behavior testing, and try `ddev logs`, `ddev logs -f`, and `ddev ssh` to review the /var/log/php-fpm.log and /var/log/nginx/*.log

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

