### PR TITLE
Put nginx back on port 80 internally in container

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -64,6 +64,9 @@ RUN apt-get -qq update && \
     apt-get -qq clean -y && \
 	rm -rf /var/lib/apt/lists/*
 
+# Arbitrary user needs to be able to bind to privileged ports (for nginx)
+RUN setcap CAP_NET_BIND_SERVICE=+eip /usr/sbin/nginx
+
 ADD files /
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
@@ -99,7 +102,7 @@ RUN mkdir -p /home/.composer /home/.drush/commands && chmod 777 /home && chmod -
 RUN touch /var/log/nginx/error.log /var/log/nginx/access.log /var/log/php-fpm.log && \
   chmod 666 /var/log/nginx/error.log /var/log/nginx/access.log /var/log/php-fpm.log
 
-EXPOSE 8080 8025
+EXPOSE 80 8025
 HEALTHCHECK --interval=2s --retries=5 CMD ["/healthcheck.sh"]
 
 CMD ["/start.sh"]

--- a/files/etc/nginx/nginx-site-backdrop.conf
+++ b/files/etc/nginx/nginx-site-backdrop.conf
@@ -11,8 +11,8 @@ map $http_x_forwarded_proto $fcgi_https {
 }
 
 server {
-    listen 8080; ## listen for ipv4; this line is default and implied
-    listen [::]:8080 default ipv6only=on; ## listen for ipv6
+    listen 80; ## listen for ipv4; this line is default and implied
+    listen [::]:80 default ipv6only=on; ## listen for ipv6
     # The NGINX_DOCROOT variable is substituted with
     # its value when the container is started.
     root $NGINX_DOCROOT;

--- a/files/etc/nginx/nginx-site-default.conf
+++ b/files/etc/nginx/nginx-site-default.conf
@@ -11,8 +11,8 @@ map $http_x_forwarded_proto $fcgi_https {
 }
 
 server {
-    listen 8080; ## listen for ipv4; this line is default and implied
-    listen [::]:8080 default ipv6only=on; ## listen for ipv6
+    listen 80; ## listen for ipv4; this line is default and implied
+    listen [::]:80 default ipv6only=on; ## listen for ipv6
     # The NGINX_DOCROOT variable is substituted with
     # its value when the container is started.
     root $NGINX_DOCROOT;

--- a/files/etc/nginx/nginx-site-default.conf
+++ b/files/etc/nginx/nginx-site-default.conf
@@ -27,6 +27,7 @@ server {
     access_log /var/log/nginx/access.log;
 
     location / {
+        absolute_redirect off;
         try_files $uri $uri/ /index.php?q=$uri&$args;
     }
 

--- a/files/etc/nginx/nginx-site-drupal6.conf
+++ b/files/etc/nginx/nginx-site-drupal6.conf
@@ -21,8 +21,8 @@ map $uri $no_slash_uri {
 }
 
 server {
-    listen 8080; ## listen for ipv4; this line is default and implied
-    listen [::]:8080 default ipv6only=on; ## listen for ipv6
+    listen 80; ## listen for ipv4; this line is default and implied
+    listen [::]:80 default ipv6only=on; ## listen for ipv6
     # The NGINX_DOCROOT variable is substituted with
     # its value when the container is started.
     root $NGINX_DOCROOT;

--- a/files/etc/nginx/nginx-site-drupal6.conf
+++ b/files/etc/nginx/nginx-site-drupal6.conf
@@ -37,6 +37,7 @@ server {
     access_log /var/log/nginx/access.log;
 
     location / {
+        absolute_redirect off;
         try_files $uri /index.php?q=$no_slash_uri&$args;
     }
 

--- a/files/etc/nginx/nginx-site-drupal7.conf
+++ b/files/etc/nginx/nginx-site-drupal7.conf
@@ -11,8 +11,8 @@ map $http_x_forwarded_proto $fcgi_https {
 }
 
 server {
-    listen 8080; ## listen for ipv4; this line is default and implied
-    listen [::]:8080 default ipv6only=on; ## listen for ipv6
+    listen 80; ## listen for ipv4; this line is default and implied
+    listen [::]:80 default ipv6only=on; ## listen for ipv6
     # The NGINX_DOCROOT variable is substituted with
     # its value when the container is started.
     root $NGINX_DOCROOT;

--- a/files/etc/nginx/nginx-site-drupal7.conf
+++ b/files/etc/nginx/nginx-site-drupal7.conf
@@ -27,6 +27,8 @@ server {
     access_log /var/log/nginx/access.log;
 
     location / {
+        absolute_redirect off;
+
         # First attempt to serve request as file, then
         # as directory, then fall back to index.html
         try_files $uri $uri/ /index.php?q=$uri&$args;

--- a/files/etc/nginx/nginx-site-drupal8.conf
+++ b/files/etc/nginx/nginx-site-drupal8.conf
@@ -11,8 +11,8 @@ map $http_x_forwarded_proto $fcgi_https {
 }
 
 server {
-    listen 8080; ## listen for ipv4; this line is default and implied
-    listen [::]:8080 default ipv6only=on; ## listen for ipv6
+    listen 80; ## listen for ipv4; this line is default and implied
+    listen [::]:80 default ipv6only=on; ## listen for ipv6
     # The NGINX_DOCROOT variable is substituted with
     # its value when the container is started.
     root $NGINX_DOCROOT;

--- a/files/etc/nginx/nginx-site-drupal8.conf
+++ b/files/etc/nginx/nginx-site-drupal8.conf
@@ -27,6 +27,7 @@ server {
     access_log /var/log/nginx/access.log;
 
     location / {
+        absolute_redirect off;
         try_files $uri /index.php?$query_string; # For Drupal >= 7
     }
 

--- a/files/etc/nginx/nginx-site-typo3.conf
+++ b/files/etc/nginx/nginx-site-typo3.conf
@@ -11,8 +11,8 @@ map $http_x_forwarded_proto $fcgi_https {
 }
 
 server {
-    listen 8080; ## listen for ipv4; this line is default and implied
-    listen [::]:8080 default ipv6only=on; ## listen for ipv6
+    listen 80; ## listen for ipv4; this line is default and implied
+    listen [::]:80 default ipv6only=on; ## listen for ipv6
     # The NGINX_DOCROOT variable is substituted with
     # its value when the container is started.
     root $NGINX_DOCROOT;

--- a/files/etc/nginx/nginx-site-typo3.conf
+++ b/files/etc/nginx/nginx-site-typo3.conf
@@ -27,6 +27,7 @@ server {
     access_log /var/log/nginx/access.log;
 
     location / {
+        absolute_redirect off;
         try_files $uri $uri/ /index.php$is_args$args;
     }
 

--- a/files/etc/nginx/nginx-site-wordpress.conf
+++ b/files/etc/nginx/nginx-site-wordpress.conf
@@ -59,6 +59,7 @@ server {
     }
 
     location / {
+            absolute_redirect off;
             # This is cool because no php is touched for static content.
             # include the "?$args" part so non-default permalinks doesn't break when using query string
             try_files $uri $uri/ /index.php?$args;

--- a/files/etc/nginx/nginx-site-wordpress.conf
+++ b/files/etc/nginx/nginx-site-wordpress.conf
@@ -14,8 +14,8 @@ map $http_x_forwarded_proto $fcgi_https {
 }
 
 server {
-    listen 8080; ## listen for ipv4; this line is default and implied
-    listen [::]:8080 default ipv6only=on; ## listen for ipv6
+    listen 80; ## listen for ipv4; this line is default and implied
+    listen [::]:80 default ipv6only=on; ## listen for ipv6
 
     # Make site accessible from http://localhost/
     server_name _;

--- a/files/healthcheck.sh
+++ b/files/healthcheck.sh
@@ -4,5 +4,5 @@
 
 set -eo pipefail
 
-curl --fail localhost:8080/fpmstatus
+curl --fail localhost/fpmstatus
 curl --fail localhost:8025 >/dev/null 2>&1

--- a/test/containertest.sh
+++ b/test/containertest.sh
@@ -7,7 +7,7 @@ set -o pipefail
 set -o nounset
 
 HOST_PORT="1081"
-CONTAINER_PORT="8080"
+CONTAINER_PORT="80"
 CONTAINER_NAME=web-local-test
 DOCKER_IMAGE=$(awk '{print $1}' .docker_image)
 


### PR DESCRIPTION
## The Problem:

There was minor confusion (especially in the TYPO3 world) when nginx moved to port 8080. There were two problems:

* It was really hard to set the trustedHostPattern to something that worked
* Redirects from "typo3" to "typo3/" tended to pick up the 8080 port.

It turns out that the redirect problem was completely a separate problem, and it's fixed here by turning off absolute redirects in https://github.com/drud/docker.nginx-php-fpm-local/commit/71fff9a18844a27cde336f75f4eb3f9a31c9fcb3

## The Fix:

* Move back to port 80. The container build uses setcap to provide nginx the necessary privileges to bind to port 80.
* Turn off absolute redirects so we don't end up with the port mixed into the redirect.

This is temporarily pushed to drud/nginx-php-fpm-local:20180402_nginx_back_to_80

## The Test:

I think this is easiest to test with https://github.com/drud/ddev/pull/770 - make sure to delete your .ddev/docker-compose.yaml.

* Normal usage with a variety of configured router_http_port and router_https_port
* With a router_http_port that is not the default 80, hit the admin section of typo3 site with something like http://typo3git.ddev.local/typo3 - it should work OK. Before this patch the redirect would have contained the port (80 now, 8080 previously) of nginx in the web container.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

There are way many suggestions on the internet about how to solve this problem with nginx, it's quite common.  

* [absolute_redirect off](http://nginx.org/en/docs/http/ngx_http_core_module.html#absolute_redirect) was the path that worked for me (finally) in the web container. 
* Some suggest [proxy_redirect](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_redirect) in the proxy (ddev-router)
* Stackexchange questions with appropriate answers:
    * https://serverfault.com/questions/174297/nginx-apache-trailing-slash-redirect
    * https://serverfault.com/questions/351212/nginx-redirects-to-port-8080-when-accessing-url-without-slash
    * https://stackoverflow.com/questions/33003069/nginx-proxy-pass-is-setting-port-in-response
    * https://serverfault.com/questions/379675/nginx-reverse-proxy-url-rewrite

* [google search to uncover this](https://www.google.com/search?q=nginx+proxy+redirect+to+wrong+port&oq=nginx+proxy+redirect+to+wrong+port&aqs=chrome..69i57.9887j0j4&sourceid=chrome&ie=UTF-8)




## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

