### PR TITLE
Simplify xdebug support, for drud/ddev#785, also fixes #66

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -100,7 +100,7 @@ RUN mkdir -p /etc/nginx/sites-enabled && \
 
 RUN chmod -R 777 /var/log
 
-RUN chmod -R ugo+w /usr/sbin /usr/bin /etc/nginx /var/cache/nginx /run /var/www/html /etc/php/*/*/conf.d/ /var/lib/php/modules /etc/alternatives /usr/lib/node_modules
+RUN chmod -R ugo+w /usr/sbin /usr/bin /etc/nginx /var/cache/nginx /run /var/www /etc/php/*/*/conf.d/ /var/lib/php/modules /etc/alternatives /usr/lib/node_modules
 # All users will have their home directory in /home, make it fully writeable
 RUN mkdir -p /home/.composer /home/.drush/commands && chmod 777 /home && chmod -R ugo+w /home/.composer /home/.drush
 

--- a/files/etc/php/5.6/mods-available/xdebug.ini
+++ b/files/etc/php/5.6/mods-available/xdebug.ini
@@ -1,5 +1,5 @@
 zend_extension=xdebug.so
 xdebug.remote_enable=1
-xdebug.remote_host=172.28.99.99
-xdebug.remote_port=11011
+xdebug.remote_host=host.docker.internal
+xdebug.remote_port=9000
 xdebug.max_nesting_level=512

--- a/files/etc/php/5.6/mods-available/xdebug.ini
+++ b/files/etc/php/5.6/mods-available/xdebug.ini
@@ -1,5 +1,6 @@
 zend_extension=xdebug.so
 xdebug.remote_enable=1
 xdebug.remote_host=host.docker.internal
+xdebug.remote_autostart=1
 xdebug.remote_port=9000
 xdebug.max_nesting_level=512

--- a/files/etc/php/7.0/mods-available/xdebug.ini
+++ b/files/etc/php/7.0/mods-available/xdebug.ini
@@ -1,5 +1,5 @@
 zend_extension=xdebug.so
 xdebug.remote_enable=1
-xdebug.remote_host=172.28.99.99
-xdebug.remote_port=11011
+xdebug.remote_host=host.docker.internal
+xdebug.remote_port=9000
 xdebug.max_nesting_level=512

--- a/files/etc/php/7.0/mods-available/xdebug.ini
+++ b/files/etc/php/7.0/mods-available/xdebug.ini
@@ -1,5 +1,6 @@
 zend_extension=xdebug.so
 xdebug.remote_enable=1
 xdebug.remote_host=host.docker.internal
+xdebug.remote_autostart=1
 xdebug.remote_port=9000
 xdebug.max_nesting_level=512

--- a/files/etc/php/7.1/mods-available/xdebug.ini
+++ b/files/etc/php/7.1/mods-available/xdebug.ini
@@ -1,5 +1,5 @@
 zend_extension=xdebug.so
 xdebug.remote_enable=1
-xdebug.remote_host=172.28.99.99
-xdebug.remote_port=11011
+xdebug.remote_host=host.docker.internal
+xdebug.remote_port=9000
 xdebug.max_nesting_level=512

--- a/files/etc/php/7.1/mods-available/xdebug.ini
+++ b/files/etc/php/7.1/mods-available/xdebug.ini
@@ -1,5 +1,6 @@
 zend_extension=xdebug.so
 xdebug.remote_enable=1
 xdebug.remote_host=host.docker.internal
+xdebug.remote_autostart=1
 xdebug.remote_port=9000
 xdebug.max_nesting_level=512

--- a/files/etc/php/7.2/mods-available/xdebug.ini
+++ b/files/etc/php/7.2/mods-available/xdebug.ini
@@ -1,5 +1,5 @@
 zend_extension=xdebug.so
 xdebug.remote_enable=1
-xdebug.remote_host=172.28.99.99
-xdebug.remote_port=11011
+xdebug.remote_host=host.docker.internal
+xdebug.remote_port=9000
 xdebug.max_nesting_level=512

--- a/files/etc/php/7.2/mods-available/xdebug.ini
+++ b/files/etc/php/7.2/mods-available/xdebug.ini
@@ -1,5 +1,6 @@
 zend_extension=xdebug.so
 xdebug.remote_enable=1
 xdebug.remote_host=host.docker.internal
+xdebug.remote_autostart=1
 xdebug.remote_port=9000
 xdebug.max_nesting_level=512

--- a/files/start.sh
+++ b/files/start.sh
@@ -51,7 +51,9 @@ fi
 envsubst "$NGINX_SITE_VARS" < "$NGINX_SITE_TEMPLATE" > /etc/nginx/sites-enabled/nginx-site.conf
 
 # Disable xdebug by default. Users can enable with /usr/local/bin/enable_xdebug
-disable_xdebug
+if [ "$DDEV_XDEBUG_ENABLED" != "true" ]; then
+    disable_xdebug
+fi
 
 echo 'Server started'
 


### PR DESCRIPTION
## The Problem:

XDebug support was difficult and required piles of work, including adding an IP address. but now that docker provides us a way to reach the host with host.docker.internal, we don't have to do that any more.

## The Fix:

* Use xdebug.remote_host=host.docker.internal 
* Use xdebug.remote_autostart=1 so it "just works"
* Use the default port, 9000, instead of making them change the port.
* Happens to fix #66 in passing also (/var/www should be world-writeable)
* Add support for the DDEV_XDEBUG_ENABLED environment variable, if set to "true" we turn on xdebug. All previous techniques to turn on xdebug still work.

## Manual Test:

* Easiest to test in https://github.com/drud/ddev/pull/785

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

