### PR TITLE
Fix NGINX url rewrite for TYPO3

### DIFF
--- a/files/etc/nginx/nginx-site-typo3.conf
+++ b/files/etc/nginx/nginx-site-typo3.conf
@@ -28,7 +28,7 @@ server {
 
     location / {
         absolute_redirect off;
-        try_files $uri $uri/ /index.php$is_args$args;
+        try_files $uri $uri/ /index.php$args;
     }
 
     # pass the PHP scripts to FastCGI server listening on socket


### PR DESCRIPTION
## The Problem:
NGINX url rewriting is not working for TYPO3.  

## The Fix:
Remove `$is_args` from query

## Automation Overview:
With `$is_args` param, NGINX url rewriting is not working.
`$is_args` is adding `?` char that may create duplicate `??`

## Related Issue Link(s):
ps: this may calm down a little issue with Apache support :)
