### PR TITLE
fixes nginx conf for access to d8 update.php, fixes drud/ddev#830

### DIFF
--- a/files/etc/nginx/nginx-site-drupal8.conf
+++ b/files/etc/nginx/nginx-site-drupal8.conf
@@ -43,8 +43,7 @@ server {
     }
 
     # pass the PHP scripts to FastCGI server listening on socket
-    location ~ \.php$ {
-        try_files $uri =404;
+    location ~ '\.php$|^/update.php' {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass unix:/run/php-fpm.sock;
         fastcgi_buffers 16 16k;


### PR DESCRIPTION
## The Problem:
drud/ddev#830 - Accessing update.php/selection results in a 404

## The Fix:
Update the location rule and remove `try_files $uri =404;` to allow access to update.php/selection. Thanks to @mglaman for reporting the issue along with a fix!

## The Test:

- Spin up a d8 site w/ ddev setting `webimage` in .ddev/config to `drud/nginx-php-fpm-local:fix-d8-updatephp`
- Be sure to configure settings.php w/ a CMI directory so you can proceed to the second screen in update.php
- Go to update.php and proceed to the second screen. You should not get a 404 from nginx or drupal, you should get the next update.php screen.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

